### PR TITLE
more appropriate error message status codes (.NET)

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -77,7 +77,7 @@ public class proxy : IHttpHandler {
 
             string errorMsg = ex.InnerException.Message + " " + uri;
             log(TraceLevel.Error, errorMsg);
-            sendErrorResponse(context.Response, null, errorMsg, System.Net.HttpStatusCode.BadRequest);
+            sendErrorResponse(context.Response, null, errorMsg, System.Net.HttpStatusCode.InternalServerError);
             return;
         }  
         //if mustMatch was set to true and url wasn't in the list


### PR DESCRIPTION
throw a 400 (and more specific XML parsing error)
throw a 400 for no url as well.
