### PR TITLE
please, consider returning http error codes instead of internal error co...

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -282,7 +282,7 @@ class Proxy {
 
         $this->proxyLog->log("Malformed 'mustMatch' property in config");
 
-        header('Status: 200', true, 200);
+        header('Status: 412', true, 412);
 
         header('Content-Type: application/json');
 
@@ -302,7 +302,7 @@ class Proxy {
 
         $this->proxyLog->log("Rate meter exceeded by " . $_SERVER['REMOTE_ADDR']);
 
-        header('Status: 200', true, 200);
+        header('Status: 402', true, 402);
 
         header('Content-Type: application/json');
 
@@ -322,7 +322,7 @@ class Proxy {
 
         $this->proxyLog->log("Proxy could not resolve requested url - " . $this->proxyUrl . ".  Possible solution would be to update 'mustMatch', 'matchAll' or 'url' property in config.");
 
-        header('Status: 200', true, 200);
+        header('Status: 403', true, 403);
 
         header('Content-Type: application/json');
 
@@ -340,7 +340,7 @@ class Proxy {
     public function allowedApplicationError()
     {
 
-        header('Status: 200', true, 200);
+        header('Status: 402', true, 402);
 
         header('Content-Type: application/json');
 


### PR DESCRIPTION
...des in the returned JSON

it's much harder to identify, track and debug proxy configuration problems, as they are invisible in browser developer tools unless you look at the actual content of responses
