### PR TITLE
update "/rest" to "/rest/" to check for infourl

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -233,7 +233,7 @@ private String getNewTokenIfCredentialsAreSpecified(ServerUrl su, String url) th
             }
         } else {
             //standalone ArcGIS Server token-based authentication
-            int infoIndex = url.toLowerCase().indexOf("/rest");
+            int infoIndex = url.toLowerCase().indexOf("/rest/");
             if (infoIndex != -1) {
 
                 String infoUrl = url.substring(0, infoIndex);


### PR DESCRIPTION
this update to prevent error in getting the infourl if the request host name include "/rest", like "http://reston.example.com", as mentioned in #5 
