### PR TITLE
fix for trailing slash problem

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -594,7 +594,7 @@ public class ProxyConfig
 
     public ServerUrl GetConfigServerUrl(string uri) {                       
         //split both request and proxy.config urls and compare them
-        string[] uriParts = uri.Split(new char[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+        string[] uriParts = uri.Split(new char[] {'/','?'}, StringSplitOptions.RemoveEmptyEntries); 
         string[] configUriParts = new string[] {};
                 
         foreach (ServerUrl su in serverUrls) {


### PR DESCRIPTION
proposed fix for trailing slash problem that retains check to avoid
baddomain attacks (ie: server.com.baddomain.com)

jg 3/18/2014
1. overwrote original change based on suggestions from @nshampur with the help of @afili and @esoekianto.
2. this fix ensure that we no longer check to enforce a particular protocol for requests (ie: http and https are both allowed.) 
3 also implements a check when matchAll is 'false' for a particular <serverUrl> for the first time.
4. added a step to decode encoded urls.
