### PR TITLE
Java: fix for trailing slash problem and encoded url

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -578,8 +578,7 @@ public static class ProxyConfig
         }       
     	
         if (this.mustMatch)
-        	throw new IllegalStateException("The proxy tried to resolve a prohibited or malformed 'url'. The server does not meet one of the preconditions that the requester put on the request.",
-                "403 - Forbidden: Access is denied.");
+        	throw new IllegalArgumentException("The proxy tried to resolve a prohibited or malformed 'url'. The server does not meet one of the preconditions that the requester put on the request.403 - Forbidden: Access is denied.");
         else
         	return new ServerUrl(uri); //if mustMatch is false send the server url back that is the same the uri to pass thru     
     }


### PR DESCRIPTION
proposed fix for trailing slash problem that retains check to avoid
baddomain attacks (ie: server.com.baddomain.com)
