### PR TITLE
Enable redirects in PHP proxy, Fixes #47

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -752,6 +752,8 @@ class Proxy {
         curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST , false);
 
         curl_setopt($this->ch, CURLOPT_HEADER, true);
+        
+        curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
 
     }
 


### PR DESCRIPTION
This code fixes failure to redirect.  Tested with this example, `proxy.php?http://services.arcgisonline.com`.
