### PR TITLE
Detect decode character encoding, Fixes #21

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -414,6 +414,7 @@ class Proxy {
 
     public function setupClassProperties()
     {
+    	$this->decodeCharacterEncoding(); // Sanitize url being proxied and removing encodings if present
 
         try {
 
@@ -456,6 +457,25 @@ class Proxy {
             $this->proxyLog->log("Proxy could not detect request method action type (POST, GET, FILES).");
         }
 
+    }
+    
+    public function decodeCharacterEncoding()
+    {
+    	$hasHttpEncoding = $this->startsWith($_SERVER['QUERY_STRING'], 'http%3a%2f%2f');
+    	
+    	$hasHttpsEncoding = $this->startsWith($_SERVER['QUERY_STRING'], 'https%3a%2f%2f');
+    	
+    	if($hasHttpEncoding || $hasHttpsEncoding){
+    		
+    		$_SERVER['QUERY_STRING'] = urldecode($_SERVER['QUERY_STRING']); //Remove encoding from GET requests
+    		
+    		foreach($_POST as $k => $v) {
+    			
+    			$_POST[$k] = urldecode($v);  //Remove encoding for each POST value
+    			
+    		}
+    		
+    	}
     }
 
     public function formatWithPrefix($url)


### PR DESCRIPTION
When various class properties are set, a check is made to look for encoding.  If character encoding is present, decoding happens on the URL and on the POST data.  This takes place before the requested URL is evaluated against the config.
