### PR TITLE
DotNet : Improve return status codes and message from server when error is encountered

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -426,7 +426,6 @@ public class proxy : IHttpHandler {
             message += string.Format(",details:[message:\"{0}\"]", errorDetails);
         message += "}}";
         response.StatusCode = (int)errorCode;
-        response.StatusDescription = message;
         //this displays our customized error messages instead of IIS's custom errors
         response.TrySkipIisCustomErrors = true;
         response.Write(message);


### PR DESCRIPTION
Improved logic so that appropriate status and message are returned in these scenarios

1) Invalid url format - http://services.arcgisonline.com/ArcGIS/rest/services/?f=woops
2) Server not found or cannot be reached
3) Method not allowed - http://sampleserver6.arcgisonline.com/arcgis/rest/services/SaveTheBay/FeatureServer/0/applyEdits

The message will include the uri as it is in the request and not the responseUri, therefore the token will not be exposed and the message will not return anything that is not supposed to.
