### PR TITLE
Java: missing tolowercase on url comparison

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -574,7 +574,7 @@ public static class ProxyConfig
             //skip comparing the protocol, so that either http or https is considered valid
             for (i = 1; i < configUriParts.length; i++)                
             {
-                if (!configUriParts[i].equals(uriParts[i]) ) break;                    
+                if (!configUriParts[i].toLowerCase().equals(uriParts[i].toLowerCase()) ) break;                      
             }
             if (i == configUriParts.length)
             {


### PR DESCRIPTION
mimic .NET #80
comparison of urls in config file and requests should be case insensitive
