### PR TITLE
Java: change to use startsWith to avoid RTE error

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -748,8 +748,7 @@ try {
         }
 
         //check if the uri is encoded then decode it
-        if (ProxyConfig.isUrlPrefixMatch("http%3a%2f%2f", uri) || ProxyConfig.isUrlPrefixMatch("https%3a%2f%2f", uri) )
-        	uri= URLDecoder.decode(uri, "UTF-8");
+         if (uri.startsWith("http%3a%2f%2f") || uri.startsWith("https%3a%2f%2f")) uri= URLDecoder.decode(uri, "UTF-8");
 
         String[] allowedReferers = getConfig().getAllowedReferers();
         if (allowedReferers != null && allowedReferers.length > 0 && request.getHeader("referer") != null){


### PR DESCRIPTION
proposed fix for #43
