### PR TITLE
pass status code along with gzip html error

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -225,6 +225,7 @@ public class proxy : IHttpHandler {
                         responseStream.Write(bytes, 0, bytesRead);
                     }
 
+                    context.Response.StatusCode = (int)(webExc.Response as System.Net.HttpWebResponse).StatusCode;
                     context.Response.OutputStream.Write(bytes, 0, bytes.Length);
                 }
             }


### PR DESCRIPTION
Improved the fix for issue #44 in order to pass appropriate status code in the response headers
