### PR TITLE
Improve error shown for missing config file

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -333,7 +333,7 @@ private void cleanUpRatemap(ConcurrentHashMap<String, RateMeter> ratemap) {
         if (config != null)
             return config;
         else
-            throw new FileNotFoundException("The proxy configuration file does not exist at application root, or is not readable.");
+            throw new FileNotFoundException("The proxy configuration file");
     }
 
     //writing Log file


### PR DESCRIPTION
Change the displayed error message from
`HTTP Status 404 - The proxy configuration file does not exist at application root,
or is not readable. is NOT Found.`
to 
`HTTP Status 404 - The proxy configuration file is NOT Found.`
