### PR TITLE
Improve PHP error shown for missing config file

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -2372,6 +2372,24 @@ class XmlParser
     {
         $data = file($f);
 
+        // Check that configuration file can be read, and that it's not empty
+        if (!$data) {
+            $message = "Proxy error: problem reading proxy configuration file.";
+            // This is before we have the log location, so we cannot log to logfile
+
+            header('Status: 403', true, 403);  // 403 Forbidden - The server understood the request, but is refusing to fulfill it. For example, if a directory or file is unreadable due to file permissions.
+
+            header('Content-Type: application/json');
+
+            $configError = array(
+                    "error" => array("code" => 403,
+                        "details" => array("$message"),
+                        "message" => "$message"
+                    ));
+
+            die(json_encode($configError));     
+        }
+        
         $xml = implode("\n", $data);
 
         return $this->parse($xml);


### PR DESCRIPTION
Improve the current 403 message for when config file is missing or empty from
`{"error":{
    "code":403,
    "details":["This proxy does not support empty parameters."],
    "message":"This proxy does not support empty parameters."
}}`
to 
`{"error":{
    "code":403,"
    details":["Proxy error: problem reading proxy configuration file."],
    "message":"Proxy error: problem reading proxy configuration file."
}}`
