### PR TITLE
Java: allow to ping proxy for quick test

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -766,6 +766,15 @@ try {
             return;
         }
 
+        if (uri.equalsIgnoreCase("ping")){
+            response.setStatus(200);
+            String msg="Reply from proxy";
+            OutputStream output = response.getOutputStream();
+            output.write(msg.getBytes());
+            output.flush();
+            return;
+        }
+
         //check if the uri is encoded then decode it
          if (uri.startsWith("http%3a%2f%2f") || uri.startsWith("https%3a%2f%2f")) uri= URLDecoder.decode(uri, "UTF-8");
 


### PR DESCRIPTION
This is adopted from Silverlight version of the proxy page, it will allow user to quickly test if the proxy page has been setup correctly in the web server.

`http://<servername>/<foldername>/proxy.jsp?ping`

then it will return "Reply from proxy" with 200 code

idea from @jgravois
