### PR TITLE
Respond with compressed gzip, Fixes 125

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -792,7 +792,7 @@ class Proxy {
 
     public function initCurl()
     {
-        $headers = array('Expect:', 'Referer: ' . $this->referer);
+        $headers = array('Accept-Encoding: compress, gzip','Expect:', 'Referer: ' . $this->referer);
 
         $this->ch = curl_init();
 


### PR DESCRIPTION
Made sure when talking to GIS server to include Accept-Encoding gzip property.
