### PR TITLE
Java: use error 429 for rate limiting

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -833,7 +833,7 @@ try {
                 _log(Level.WARNING,"Pair " + key + " is throttled to " + serverUrl.getRateLimit() + " requests per " + serverUrl.getRateLimitPeriod() + " minute(s). Come back later.");
 
                 sendErrorResponse(response,"This is a metered resource, number of requests have exceeded the rate limit interval.",
-                        "Unable to proxy request for requested resource.",HttpServletResponse.SC_PAYMENT_REQUIRED);
+                        "Error 429 - Too Many Requests",429);
 
                 return;
             }


### PR DESCRIPTION
proposed fix for #69

BEFORE
"error": {"code": 402,"details": ["This is a metered resource, number of requests have exceeded the rate limit interval."], "message": "Unable to proxy request for requested resource."}}

AFTER
"error": {"code": 429,"details": ["This is a metered resource, number of requests have exceeded the rate limit interval."], "message": "Error 429 - Too Many Requests"}}
