### PR TITLE
Java: set encoding to gzip if not set by response

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -110,16 +110,21 @@ private boolean fetchAndPassBackToClient(HttpURLConnection con, HttpServletRespo
         Set<String> headerFieldsSet = headerFields.keySet();
         Iterator<String> hearerFieldsIter = headerFieldsSet.iterator();
 
+        boolean encoding = false;
+
         while (hearerFieldsIter.hasNext()){
             String headerFieldKey = hearerFieldsIter.next();
             List<String> headerFieldValue = headerFields.get(headerFieldKey);
             StringBuilder sb = new StringBuilder();
+            if (headerFieldKey != null && headerFieldKey.contains("Encoding")) encoding = true;
             for (String value : headerFieldValue) {
                 sb.append(value);
                 sb.append("");
             }
             if (headerFieldKey != null) clientResponse.addHeader(headerFieldKey, sb.toString());            
         }
+
+        if (!encoding) clientResponse.addHeader("Accept-Encoding", "gzip");
 		
 		InputStream byteStream;
 		if (con.getResponseCode() >= 400 && con.getErrorStream() != null){


### PR DESCRIPTION
proposed fix for #125

I thought this was taken care by the previous pull request #114 by setting all headers from response, but some responses don't contain the encoding in the header for some reason, this should make sure. 
