### PR TITLE
DotNet: pass error code number

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -448,7 +448,7 @@ public class proxy : IHttpHandler {
 
     private static void sendErrorResponse(HttpResponse response, String errorDetails, String errorMessage, System.Net.HttpStatusCode errorCode)
     {
-        String message = string.Format("{{error: {{code: {0},message:\"{1}\"", errorCode, errorMessage);
+        String message = string.Format("{{error: {{code: {0},message:\"{1}\"", (int)errorCode, errorMessage);
         if (!string.IsNullOrEmpty(errorDetails))
             message += string.Format(",details:[message:\"{0}\"]", errorDetails);
         message += "}}";


### PR DESCRIPTION
This will fix #90 issue in order to display the error code and not the description
