### PR TITLE
ping config error message to just say not readable

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -840,7 +840,7 @@ try {
         }
 
         if (uri.equalsIgnoreCase("ping")){
-            String checkConfig = (getConfig().canReadProxyConfig() == true) ? "OK": "Not Exist/Readable";
+            String checkConfig = (getConfig().canReadProxyConfig() == true) ? "OK": "Not Readable";
             String checkLog = (okToLog() == true) ? "OK": "Not Exist/Readable";
             _sendPingMessage(response, version, checkConfig, checkLog);
             return;


### PR DESCRIPTION
since we would not never get to a point to run this ping when the config file does not exist, and see the error message of missing configuration file.

So the error message will only show if the config file is not readable. 
