### PR TITLE
.NET RegEx to remove whitespace in allowedReferers

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -16,6 +16,7 @@ using System.Xml.Serialization;
 using System.Web.Caching;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 public class proxy : IHttpHandler {
 
@@ -716,7 +717,7 @@ public class ProxyConfig
         get { return allowedReferers; }
         set
         {
-            allowedReferers = value;
+            allowedReferers = Regex.Replace(value, @"\s", "");
         }
     }
 


### PR DESCRIPTION
in the .NET proxy.ashx, added a RegularExpression to remove whitespace
characters from the allowedReferers.

This lets us put in spaces, line breaks, tabs, etc. to keep the
proxy.config looking well formatted and easy to read, but still lets the
proxy.ashx split the string at commas.
