### PR TITLE
Java:pass all header from request to connection request properties

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -160,7 +160,7 @@ private boolean passHeadersInfo(HttpServletRequest request, HttpURLConnection co
     while (headerNames.hasMoreElements()) {
         String key = (String) headerNames.nextElement();
         String value = request.getHeader(key);
-        con.setRequestProperty(key, value);
+        if (!key.equalsIgnoreCase("host")) con.setRequestProperty(key, value);
     }
     return true; 
 }


### PR DESCRIPTION
this fixed WMS issue #163 

and possibly better solution to #132 and fixed #125, but @bsvensson please include this to teja to test more

This will pass these headers from request to connection, 
# 

request header Host= localhost:9083
request header Connection= keep-alive
request header Pragma= no-cache
request header Cache-Control= no-cache
request header Accept= text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,_/_;q=0.8
request header User-Agent= Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36
request header Accept-Encoding= gzip,deflate,sdch
request header Accept-Language= en-US,en;q=0.8
# 

![allheaders](https://cloud.githubusercontent.com/assets/5265339/5111180/a73e041a-6fd3-11e4-9e6b-fe63675b6470.PNG)
