### PR TITLE
DotNet: support system-level proxy settings

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -398,6 +398,9 @@ public class proxy : IHttpHandler {
         req.Referer = referer;
         req.Method = method;
 
+        // Use the default system proxy
+        req.Proxy = System.Net.HttpWebRequest.GetSystemWebProxy();
+
         if (credentials != null)
             req.Credentials = credentials;
         


### PR DESCRIPTION
The DotNet proxy script did not obey system-level proxy settings (to be specific, the Internet Explorer proxy settings of the currently impersonated user). Because of this, the script will fail in environments which require a web proxy for outgoing connections. This change adds support for system proxy settings on outgoing http web requests through [WebRequest.GetSystemWebProxy](http://msdn.microsoft.com/en-us/library/system.net.webrequest.getsystemwebproxy%28v=vs.110%29.aspx). The change is backward compatible in the sense that, if no system proxy is configured for the current user, requests will still default to a direct connection.

Tested on Windows 7 Enterprise and Windows Server 2012 R2, IIS 8.5, .NET 4.5.2, on REST queries sent to ArcGIS Server, Geoserver, and OSM Overpass API.
