### PR TITLE
DotNet Set Default Value for ServerUrl.Domain

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -832,4 +832,10 @@ public class ServerUrl {
         get { return string.IsNullOrEmpty(rateLimitPeriod)? 60 : int.Parse(rateLimitPeriod); }
         set { rateLimitPeriod = value.ToString(); }
     }
+
+    public ServerUrl()
+    {
+        // Set initial value to avoid requiring Domain parameter in proxy.config
+        this.Domain = "";
+    }
 }


### PR DESCRIPTION
- DotNet proxy.
- Allow users to skip setting the value for ServerUrl.Domain in the
proxy.config file if it's equal to empty string.
- Otherwise, proxy fails if user doesn't set a value for domain.
- Related to #118
- This will allow this configuration
Sample configuration: <serverUrl
url="http://artemisf/arcgis/rest/services/California/MapServer"
matchAll="true" username="XXX" password="XXX"/>