### PR TITLE
Remove declaration of support for HTTP range requests

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -323,6 +323,7 @@ public class proxy : IHttpHandler {
             {
                 case "content-type":
                 case "transfer-encoding":
+                case "accept-ranges":   // Prevent requests for partial content
                     continue;
                 default:
                     toResponse.AddHeader(headerKey, fromResponse.Headers[headerKey]);


### PR DESCRIPTION
## The problem

When a resource response includes an "Accept-Ranges" HTTP header, the proxy will forward this header to the client. The browser interprets this to mean that requests for partial content can be made on that resource. The browser may then perform a range request, using the "Range" header. For instance:

```
Range:bytes=32768-862445
```

When the proxy receives this request, it does not forward the desired range to the target server.
## An example

When a PDF is requested through the proxy, the server will return the full content of the PDF file, but will include an Accept-Ranges header to indicate that partial data ranges can be requested. PDF viewers (Adobe / Chrome) will notice the header and perform a partial range request for the first 32k or so of the file. Since the proxy does not support these queries, the PDF download will hang.
http://serverfault.com/questions/61424/why-are-we-seeing-apache-206-partial-responses-for-pdf-downloads
## The fix

The DotNet proxy has been modified so as to not to forward the "Accept-Range" header to the client.
## Other solutions

A better solution would be to forward all request headers to the target server, with the exception of those set by the proxy script. It would be very similar to how the copyHeaders function works, but would operate on request headers instead of response headers. This would require changing the design of the script.

Here is an explanation for how the Accept-Ranges header works: http://benramsey.com/blog/2008/05/206-partial-content-and-range-requests/
