### PR TITLE
Java: split query string and uri for POST request

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -159,7 +159,7 @@ private HttpURLConnection doHTTPRequest(String uri, String method) throws IOExce
     String contentType = null;
     if (method.equals("POST")){
         String[] uriArray = uri.split("\\?");
-
+        uri = uriArray[0];
         if (uriArray.length > 1){
             contentType = "application/x-www-form-urlencoded";
             String queryString = uriArray[1];


### PR DESCRIPTION
split the query string from uri for POST request, to support token request for server 10.3 

should fix #177 