### PR TITLE
DotNet: split query string and uri for POST request

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -376,7 +376,7 @@ public class proxy : IHttpHandler {
         if (method.Equals("POST"))
         {
             String[] uriArray = uri.Split('?');
-
+            uri = uriArray[0];
             if (uriArray.Length > 1)
             {
                 contentType = "application/x-www-form-urlencoded";


### PR DESCRIPTION
split the query string from uri for POST request, to support token request for server 10.3

should fix #177 
