### PR TITLE
Pass back full response, fixes #190

### DIFF
--- a/PHP/proxy-verification.php
+++ b/PHP/proxy-verification.php
@@ -119,7 +119,7 @@ function getShmopMessage($shmop)
     if($shmop == true)
     {
         $message = "Pass";
-    }else if($shmop == false){
+    }elseif($shmop == false){
         $message = "Warning";
     }else{
         $message = "Fail";
@@ -133,7 +133,7 @@ function getMbstringMessage($mbstring)
     if($mbstring == true)
     {
         $message = "Pass";
-    }else if($mbstring == false){
+    }elseif($mbstring == false){
         $message = "Warning";
     }else{
         $message = "Fail";
@@ -145,7 +145,9 @@ function versionPhpCheck()
 {
     if (version_compare(PHP_VERSION, '5.4.2') >= 0) {
         return "Pass";
-    }else{
+    }elseif(version_compare(PHP_VERSION, '5.3.0', '>=') && version_compare(PHP_VERSION, '5.4.1', '<=')){
+        return "Warning";
+	}else{
         return "Fail";
     }
 }

--- a/PHP/proxy-verification.php
+++ b/PHP/proxy-verification.php
@@ -201,9 +201,7 @@ $curl = in_array('curl', $extensions);
 
 </table>
 
-<div>
-<p><small><?php $inipath = php_ini_loaded_file(); echo "Loaded php.ini path:  <i>" . $inipath . "</i>"; ?></small></p>
-</div>
+
 
 </div>
 </body>

--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -675,28 +675,26 @@ class Proxy {
         } else if ($this->proxyConfig['mustmatch'] == true || $this->proxyConfig['mustmatch'] == "true") {
 
             foreach ($this->serverUrls as $key => $value) {
+                
+                $serverUrl = $value['serverurl'][0];
 
-                $s = $value['serverurl'][0];
+                $serverUrl['url'] = $this->sanitizeUrl($serverUrl['url']); //Do all the URL cleanups and checks at once
+                
+                if(is_string($serverUrl['matchall'])){
 
-                $s['url'] = $this->sanitizeUrl($s['url']); //Do all the URL cleanups and checks at once
-
-                if(is_string($s['matchAll'])){
-
-                    $mustmatch = strtolower($s['matchAll']);
-
-                    $s['matchAll'] = $mustmatch;
+                    $serverUrl['matchAll'] = strtolower($serverUrl['matchall']);
 
                 }
 
-                if ($s['matchAll'] == true || $s['matchAll'] === "true") {
+                if ($serverUrl['matchall'] == true || $serverUrl['matchall'] === "true") {
 
-                    $urlStartsWith = $this->startsWith($this->proxyUrl, $s['url']);
+                    $urlStartsWith = $this->startsWith($this->proxyUrl, $serverUrl['url']);
 
                     if ($urlStartsWith){
 
-                        $this->resource = $s;
+                        $this->resource = $serverUrl;
 
-                        $this->sessionUrl = $s['url'];
+                        $this->sessionUrl = $serverUrl['url'];
 
                         $canProcess = true;
 
@@ -704,15 +702,15 @@ class Proxy {
 
                     }
 
-                } else if ($s['matchAll'] == false || $s['matchAll'] === "false"){
+                } else if ($serverUrl['matchall'] == false || $serverUrl['matchall'] === "false"){
 
-                    $isEqual = $this->equals($this->proxyUrl, $s['url']);
+                    $isEqual = $this->equals($this->proxyUrl, $serverUrl['url']);
 
                     if($isEqual){
 
-                        $this->resource = $s;
+                        $this->resource = $serverUrl;
 
-                        $this->sessionUrl = $s['url'];
+                        $this->sessionUrl = $serverUrl['url'];
 
                         $canProcess = true;
 

--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -494,6 +494,50 @@ class Proxy {
         $this->proxyBody = substr($this->responseClone, $this->contentLength);
         
     }
+    
+    public function parse_resource_headers($raw_headers) //Takes the cURL response header (from the resource) and parses it into array
+    {
+        $headers = array();  //Thanks to this http://stackoverflow.com/questions/6368574/how-to-get-the-functionality-of-http-parse-headers-without-pecl
+    
+        $key = '';
+    
+        foreach(explode("\n", $raw_headers) as $i => $h) {
+    
+            $h = explode(':', $h, 2);
+    
+            if (isset($h[1])) {
+    
+                if (!isset($headers[$h[0]]))
+    
+                    $headers[$h[0]] = trim($h[1]);
+    
+                elseif (is_array($headers[$h[0]])) {
+    
+                    $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1])));
+    
+                } else {
+    
+                    $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1])));
+                }
+    
+                $key = $h[0];
+    
+            } else {
+    
+                if (substr($h[0], 0, 1) == "\t"){
+    
+                    $headers[$key] .= "\r\n\t".trim($h[0]);
+    
+                } elseif (!$key){
+    
+                    $headers[0] = trim($h[0]);
+    
+                }
+            }
+        }
+    
+        return $headers;
+    }
 
     public function getResponse()
     {
@@ -689,6 +733,7 @@ class Proxy {
                 if ($serverUrl['matchall'] == true || $serverUrl['matchall'] === "true") {
 
                     $urlStartsWith = $this->startsWith($this->proxyUrl, $serverUrl['url']);
+
 
                     if ($urlStartsWith){
 

--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -357,6 +357,34 @@ class Proxy {
 
         exit();
     }
+    
+    public function curlError()
+    {
+    	// see full of cURL error codes at http://curl.haxx.se/libcurl/c/libcurl-errors.html
+    
+    	$message = "cURL error (" . curl_errno($this->ch) . "): "
+    			. curl_error($this->ch) . ".";
+    	
+    	$this->proxyLog->log($message);
+    
+    	header('Status: 502', true, 502);  // 502 Bad Gateway -  The server, while acting as a gateway or proxy, received an invalid response from the upstream server it accessed in attempting to fulfill the request.
+    
+    	header('Content-Type: application/json');
+    
+    	$configError = array(
+    			"error" => array("code" => 502,
+    					"details" => array($message),
+    					"message" => "Proxy failed due to curl error."
+    			));
+    
+    	echo json_encode($configError);
+    	
+    	curl_close($this->ch);
+    	
+    	$this->ch = null;
+    
+    	exit();
+    }
 
 
     public function checkEmptyParameters()
@@ -822,7 +850,7 @@ class Proxy {
 
             if(curl_errno($this->ch) > 0 || empty($this->response))
             {
-                $this->proxyLog->log("Curl error or no response: " . curl_error($this->ch));
+            	$this->curlError();
 
             }else{
 
@@ -882,7 +910,7 @@ class Proxy {
 
         } catch (Exception $e) {
 
-            $this->proxyLog->log($e->getMessage());
+            $this->curlError();
         }
 
         if(curl_errno($this->ch) > 0 || empty($this->response))
@@ -947,7 +975,7 @@ class Proxy {
 
             if(curl_errno($this->ch) > 0 || empty($this->response))
             {
-                $this->proxyLog->log("Curl error or no response: " . curl_error($this->ch));
+                $this->curlError();
             }else{
 
                 $this->setProxyHeaders();

--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -189,6 +189,14 @@ class Proxy {
      */
 
     private  $unlinkPath;
+    
+    /**
+     * Holds a cloned copy of the resource response
+     *
+     * @var resource
+     */
+    
+    public $responseClone;
 
 
 


### PR DESCRIPTION
Bit of header rework in this pull request.  Made sure that the proxy captures the incoming request headers from the client and uses them when making the cURL request.  

Next the PHP proxy reads the cURL response and collects all the headers.  These headers are then sent to the client along with the response.  

Occasionally folks were seeing the full response was not getting sent, aka a truncated response.  This was b/ the Content-Length property was incorrect.  The proxy now calculates Content-Length and sets the proper Content-Length property.  