### PR TITLE
JSP: set Content-Type for errors to json , #205

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -802,6 +802,7 @@ public static class ServerUrl {
 private static Object _rateMapLock = new Object();
 
 private static void sendErrorResponse(HttpServletResponse response, String errorDetails, String errorMessage, int errorCode) throws IOException{
+    response.setHeader("Content-Type", "application/json");
     String message = "{" +
             "\"error\": {" +
             "\"code\": " + errorCode + "," +


### PR DESCRIPTION
Without this pull request the Context-Type is text/html (tomcat's default).
With this pull request the Context-Type is application/json.