### PR TITLE
DotNet: Support more format for allowed referer #166

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -131,30 +131,37 @@ public class proxy : IHttpHandler {
         //referer
         //check against the list of referers if they have been specified in the proxy.config
         String[] allowedReferersArray = ProxyConfig.GetAllowedReferersArray();
-        if (allowedReferersArray != null && allowedReferersArray.Length > 0)
+        if (allowedReferersArray != null && allowedReferersArray.Length > 0 && context.Request.Headers["referer"] != null)
         {
-            bool allowed = false;
+            PROXY_REFERER = context.Request.Headers["referer"];
             string requestReferer = context.Request.Headers["referer"];
-
-            foreach (var referer in allowedReferersArray)
+            try
             {
-                if ((allowedReferersArray.Length == 1) && referer == String.Empty)
-                    break;
+                String checkValidUri = new UriBuilder(requestReferer.StartsWith("//") ? requestReferer.Substring(requestReferer.IndexOf("//") + 2) : requestReferer).Host;
 
-                if (requestReferer != null && requestReferer != String.Empty && (ProxyConfig.isUrlPrefixMatch(referer, requestReferer)) || referer == "*")
-                {
-                    allowed = true;
-                    break;
-                }
             }
-
-            if (!allowed)
+            catch (Exception e)
             {
-                string errorMsg = "Proxy is being used from an unsupported referer: " + context.Request.Headers["referer"];
-                log(TraceLevel.Error, errorMsg);
-                sendErrorResponse(context.Response, null, errorMsg, System.Net.HttpStatusCode.Forbidden);
+                log(TraceLevel.Warning, "Proxy is being used from an invalid referer: " + context.Request.Headers["referer"]);
+                sendErrorResponse(context.Response, "Error verifying referer. ", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);
                 return;
             }
+
+            if (!checkReferer(allowedReferersArray, requestReferer))
+            {
+                log(TraceLevel.Warning, "Proxy is being used from an unknown referer: " + context.Request.Headers["referer"]);
+                sendErrorResponse(context.Response, "Unsupported referer. ", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);
+            }
+
+
+        }
+
+        //Check to see if allowed referer list is specified and reject if referer is null
+        if (context.Request.Headers["referer"] == null && allowedReferersArray != null && !allowedReferersArray[0].Equals("*"))
+        {
+            log(TraceLevel.Warning, "Proxy is being called by a null referer.  Access denied.");
+            sendErrorResponse(response, "Current proxy configuration settings do not allow requests which do not include a referer header.", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);
+            return;
         }
 
         //Throttling: checking the rate limit coming from particular client IP
@@ -515,6 +522,91 @@ public class proxy : IHttpHandler {
             }
         }
         return token;
+    }
+
+    private bool checkWildcardSubdomain(String allowedReferer, String requestedReferer, String protocol)
+    {
+        String[] allowedRefererParts = Regex.Split(allowedReferer, "(\\.)");
+        String[] refererParts = Regex.Split(requestedReferer, "(\\.)");
+
+        int allowedIndex = allowedRefererParts.Length - 1;
+        int refererIndex = refererParts.Length - 1;
+        while (allowedIndex >= 0 && refererIndex >= 0)
+        {
+            if (allowedRefererParts[allowedIndex].Equals(refererParts[refererIndex], StringComparison.OrdinalIgnoreCase) || allowedRefererParts[allowedIndex].Equals(protocol+refererParts[refererIndex], StringComparison.OrdinalIgnoreCase))
+            {
+                allowedIndex = allowedIndex - 1;
+                refererIndex = refererIndex - 1;
+            }
+            else
+            {
+                if (allowedRefererParts[allowedIndex].Equals("*") || allowedRefererParts[allowedIndex].Equals(protocol + "*"))
+                {
+                    allowedIndex = allowedIndex - 1;
+                    refererIndex = refererIndex - 1;
+                    continue; //next
+                }
+                if (refererParts[refererIndex].Contains("/"))
+                {
+                    if (refererParts[refererIndex].StartsWith(allowedRefererParts[allowedIndex]) && ((refererParts[refererIndex] + "/").StartsWith(allowedRefererParts[allowedIndex] + "/")))
+                    {
+                        //check folder match. 
+                        // if domain/folder compared with domain/folders, is not a match
+                        allowedIndex = allowedIndex - 1;
+                        refererIndex = refererIndex - 1;
+                        continue; //next
+                    }
+                }
+
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private bool checkReferer(String[] allowedReferers, String referer)
+    {
+        if (allowedReferers != null && allowedReferers.Length > 0)
+        {
+            if (allowedReferers.Length == 1 && allowedReferers[0].Equals("*")) return true; //speed-up
+            foreach (String allowedReferer in allowedReferers)
+            {
+                //get protocol type
+                String protocol = "";
+                if (allowedReferer.StartsWith("http://")) protocol = "http://";
+                else if (allowedReferer.StartsWith("https://")) protocol = "https://";
+                else if (allowedReferer.StartsWith("//")) protocol = "//";
+
+                // allowedReferer = "http://" or "https://", must exact match    
+                if (protocol.Equals("http://") || protocol.Equals("https://"))
+                {
+                    if (referer.ToLower().Equals(allowedReferer.ToLower())) return true;
+                }
+                else
+                {
+                    // protocol = "//" or ""
+                    // accept "http://" "https://" "//" or ""
+                    String allowedRefererAccepted = allowedReferer;
+                    if (protocol.Equals("//"))
+                    {
+                        allowedRefererAccepted = allowedReferer.Substring(allowedReferer.IndexOf("//") + 2);
+                    }
+
+                    referer = (referer.Contains("//")) ? referer.Substring(referer.IndexOf("//") + 2) : referer;
+                    if (referer.ToLower().Equals(allowedRefererAccepted.ToLower())) return true;
+                }
+
+                if (allowedReferer.Contains("*") || referer.Contains("/"))
+                {   //try if the allowed referer contains wildcard for subdomain or folder
+
+                    if (checkWildcardSubdomain(allowedReferer, referer, protocol)) return true;
+
+                }
+
+            }
+            return false;//no-match
+        }
+        return true;//when allowedReferer is null, then allow everything
     }
 
     private string exchangePortalTokenForServerToken(string portalToken, ServerUrl su) {


### PR DESCRIPTION
Fixed #166 in DotNet

"sub.domain.com" - accept both http and https
"sub.domain.com/folder" - accept both http and https
"http://sub.domain.com" - accept only http
"https://sub.domain.com/folder" - accept only https
"//sub.domain.com" - accept both http and https
"*.domian.com" - accept both http, https, all the subdomains and folders.