### PR TITLE
Fixed issue when PROXY_REFERER has a query string

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -126,7 +126,16 @@ public class proxy : IHttpHandler {
         }
         //use actual request header instead of a placeholder, if present
         if (context.Request.Headers["referer"] != null)
+        {
             PROXY_REFERER = context.Request.Headers["referer"];
+
+            //REMOVE ANY QUERY STRINGS IN THE URL TO PASS A PROPER HTTP REFERER
+            if (PROXY_REFERER.Contains("?"))
+                //SPLIT THE STRING AND TAKE THE FIRST HALF
+                PROXY_REFERER = PROXY_REFERER.Split("?".ToCharArray())[0];
+            }
+        }
+           
 
         //referer
         //check against the list of referers if they have been specified in the proxy.config


### PR DESCRIPTION
I had an issue when the PROXY_REFERER variable had a query string already in the URL. This threw errors when generating a token (AGS 10.3.1) . I added some code to parse out the URL if a query string is present in the PROXY_REFERER variable.