### PR TITLE
try to get token from cookie

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -767,7 +767,7 @@ public class proxy : IHttpHandler {
 			int i = cookie.IndexOf(key);
 			if (i > -1) {
 				token = cookie.Substring(cookie.IndexOf('=', i) + 1).Trim();
-				token = token.Substring(0, token.IndexOf(";"));
+				token = string.IsNullOrEmpty(token) ? token.Substring(0, token.IndexOf(";")) : token;
 			}
 		}
 		if (string.IsNullOrEmpty(token))


### PR DESCRIPTION
We've been trying to develop a secure site where the token is saved off in a cookie, similar to this sample, but using [document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#A_little_framework_a_complete_cookies_readerwriter_with_full_unicode_support) instead of local storage.

Esri IdentityManager is supposed to append this cookie to all calls to the arcgis server, but it isn't working. Some calls are still going through to the server without a token appended to the url. This change is an attempt to get the proxy to check the cookie and append the token whenever IdentityManager fails to do so.

Hopefully it's not just specific to our project and may be of some use to others. It's just one additional check if the proxy hasn't managed to recover a token.

I've also moved the storeToken logic into a method, as the same code appeared in a few places (and added a few log statements).

