### PR TITLE
Added initial support for services protected with Http Basic auth

### DIFF
--- a/DotNet/README.md
+++ b/DotNet/README.md
@@ -49,6 +49,10 @@ NOTE: as of v1.1.0, log levels and log file locations are specified in proxy con
 
 * ASP.NET 4.0 or greater (4.5 is required on Windows 8/Server 2012, see [this article] (http://www.iis.net/learn/get-started/whats-new-in-iis-8/iis-80-using-aspnet-35-and-aspnet-45) for more information)
 
+## Proxy configuration settings (.NET specific)
+* The serverUrl tag has the following additional attributes in the .NET version of resource-proxy:
+    * **httpBasicAuth**: If the service you are configuring requires HTTP Basic Authentication, you must set this attribute to *true*. In addition to this, the **domain** attribute must not be set in the proxy.config for the same serverUrl. **username** and **password** are used for credentials. An example of usage for this attribute is WMS services from 3rd party vendors.
+
 ## Issues
 
 Found a bug or want to request a new feature? Let us know by submitting an issue.

--- a/DotNet/proxy.xsd
+++ b/DotNet/proxy.xsd
@@ -20,6 +20,7 @@
                                     <xs:attribute name="rateLimit" type="xs:integer" use="optional" />
                                     <xs:attribute name="rateLimitPeriod" type="xs:integer" use="optional" />
                                     <xs:attribute name="hostRedirect" type="xs:string" use="optional" />
+									<xs:attribute name="httpBasicAuth" type="xs:boolean" use="optional" />
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>


### PR DESCRIPTION
Since we are having lot of customers using OGC WMS services protected with Http Basic Auth, we need a way to use these in Javascript API applications.

Adding support for Basic Authentication to the resource-proxy seems like a doable way for now.

Much code was already there, but used for Windows Authentication. By adding another attribute, httpBasicAuth, to the xml config file and enabling PreAuthentication on the request, I was able to get this working.

