### PR TITLE
Change error response to be well-formed JSON

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -715,9 +715,9 @@ public class proxy : IHttpHandler {
 
     private static void sendErrorResponse(HttpResponse response, String errorDetails, String errorMessage, System.Net.HttpStatusCode errorCode)
     {
-        String message = string.Format("{{error: {{code: {0},message:\"{1}\"", (int)errorCode, errorMessage);
+        String message = string.Format("{{\"error\": {{\"code\": {0},\"message\":\"{1}\"", (int)errorCode, errorMessage);
         if (!string.IsNullOrEmpty(errorDetails))
-            message += string.Format(",details:[message:\"{0}\"]", errorDetails);
+            message += string.Format(",\"details\":[\"message\":\"{0}\"]", errorDetails);
         message += "}}";
         response.StatusCode = (int)errorCode;
         //custom status description for when the rate limit has been exceeded


### PR DESCRIPTION
Added quotes to the error response, so it becomes well formed JSON. This
allows the error to be captured in the client code by using JSON.Parse.