### PR TITLE
Remove Header "Transfer-Encoding" from fetched sources

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -154,7 +154,7 @@ java.text.SimpleDateFormat" %>
             //copy the response header to the response to the client
             for (String headerFieldKey : headerFieldsSet){
                 //prevent request for partial content
-                if (headerFieldKey != null && headerFieldKey.toLowerCase().equals("accept-ranges")){
+                if (headerFieldKey != null && (headerFieldKey.toLowerCase().equals("accept-ranges") || headerFieldKey.toLowerCase().equals("transfer-encoding"))){
                     continue;
                 }
 


### PR DESCRIPTION
If the accessed server posts a header field "Transfer-Encoding: chunked" (like some PHP) accessing the proxy may fail if this field is passed through... because the Transfer of the JSP itself may not be chunked. If so the Servlet-Container should add this field.

To be concrete: my Chrome browser failed to fetch content due to this "bug".

