### PR TITLE
Set ContentLength = 0 for requests with no body

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -466,12 +466,15 @@ public class proxy : IHttpHandler {
             req.Method = "POST";
             req.ContentType = string.IsNullOrEmpty(contentType) ? "application/x-www-form-urlencoded" : contentType;
             if (bytes != null && bytes.Length > 0)
+            {
                 req.ContentLength = bytes.Length;
-            else
-                req.ContentLength = 0;
-            using (Stream outputStream = req.GetRequestStream()) {
-                outputStream.Write(bytes, 0, bytes.Length);
+                using (Stream outputStream = req.GetRequestStream())
+                {
+                    outputStream.Write(bytes, 0, bytes.Length);
+                }
             }
+            else
+                req.ContentLength = 0;                
         }
         return req.GetResponse();
     }

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -467,6 +467,8 @@ public class proxy : IHttpHandler {
             req.ContentType = string.IsNullOrEmpty(contentType) ? "application/x-www-form-urlencoded" : contentType;
             if (bytes != null && bytes.Length > 0)
                 req.ContentLength = bytes.Length;
+            else
+                req.ContentLength = 0;
             using (Stream outputStream = req.GetRequestStream()) {
                 outputStream.Write(bytes, 0, bytes.Length);
             }


### PR DESCRIPTION
The remote server responds with error 411 Length Required when posting a request with no message-body. Setting ContentLength = 0 for the request fixes it. 

See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

10.4.12 411 Length Required

The server refuses to accept the request without a defined Content- Length. The client MAY repeat the request if it adds a valid Content-Length header field containing the length of the message-body in the request message.