### PR TITLE
Return after sending unknown referer response

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -167,6 +167,7 @@ public class proxy : IHttpHandler {
             {
                 log(TraceLevel.Warning, "Proxy is being used from an unknown referer: " + context.Request.Headers["referer"]);
                 sendErrorResponse(context.Response, "Unsupported referer. ", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);
+                return;
             }
 
 


### PR DESCRIPTION
Resolves errors about headers being set (by subsequent response processing) after response is sent.

