### PR TITLE
Issue 330

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -451,7 +451,7 @@ public class proxy : IHttpHandler {
     }
 
     private System.Net.WebResponse doHTTPRequest(string uri, byte[] bytes, string method, string referer, string contentType, System.Net.NetworkCredential credentials = null)
-    {
+    { 
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         System.Net.HttpWebRequest req = (System.Net.HttpWebRequest)System.Net.HttpWebRequest.Create(uri);
         req.ServicePoint.Expect100Continue = false;

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -1,4 +1,4 @@
-<%@ WebHandler Language="C#" Class="proxy" %>
+<asp:TreeView runat="server"></asp:TreeView><%@ WebHandler Language="C#" Class="proxy" %>
 
 /*
  * DotNet proxy client.
@@ -17,6 +17,7 @@ using System.Web.Caching;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Net;
 
 public class proxy : IHttpHandler {
 
@@ -451,6 +452,7 @@ public class proxy : IHttpHandler {
 
     private System.Net.WebResponse doHTTPRequest(string uri, byte[] bytes, string method, string referer, string contentType, System.Net.NetworkCredential credentials = null)
     {
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         System.Net.HttpWebRequest req = (System.Net.HttpWebRequest)System.Net.HttpWebRequest.Create(uri);
         req.ServicePoint.Expect100Continue = false;
         req.Referer = referer;


### PR DESCRIPTION
I ran into the same error as did the reporting user. Recent changes at the Census Bureau's TigerWeb service require https. Furthermore, the older SSL3 protocol doesn't seem to be supported; I found that adding support for the TLS 1.2 protocol did the trick. This change consists of a "using System.Net" clause at the top of the file, plus a call to add support for TLS 1.2 just before the request in the doHTTPRequest method.

I've only tested this update against the https://tigerweb.geo.census.gov/arcgis/rest/services service and against non-https Esri services route.arcgis.com, traffic.arcgis.com (in the sample "widget_directions_basic").