### PR TITLE
Do not copy access-control-* headers

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -377,6 +377,14 @@ public class proxy : IHttpHandler {
                 case "content-type":
                 case "transfer-encoding":
                 case "accept-ranges":   // Prevent requests for partial content
+                case "access-control-allow-origin":
+                case "access-control-allow-credentials":
+                case "access-control-expose-headers":
+                case "access-control-max-age":
+                case "access-control-allow-methods":
+                case "access-control-allow-headers":
+                case "access-control-request-method":
+                case "access-control-request-headers":
                     continue;
                 default:
                     toResponse.AddHeader(headerKey, fromResponse.Headers[headerKey]);

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -381,10 +381,6 @@ public class proxy : IHttpHandler {
                 case "access-control-allow-credentials":
                 case "access-control-expose-headers":
                 case "access-control-max-age":
-                case "access-control-allow-methods":
-                case "access-control-allow-headers":
-                case "access-control-request-method":
-                case "access-control-request-headers":
                     continue;
                 default:
                     toResponse.AddHeader(headerKey, fromResponse.Headers[headerKey]);


### PR DESCRIPTION
Do not copy access-control-* headers from remote server response, they should be set by http-proxy webserver (and they can't be duplicated in response either).