### PR TITLE
Changed method for completing the response to the web client. 

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -336,7 +336,17 @@ public class proxy : IHttpHandler {
                 fetchAndPassBackToClient(serverResponse, response, true);
             }
         }
-        response.End();
+        
+        // Use instead of response.End() to avoid the "Exception thrown: 'System.Threading.ThreadAbortException' in mscorlib.dll" error 
+        // that appears in the output of Visual Studio.  response.End() appears to only really be necessary if you need to end the thread immediately
+        // (i.e. no more code is processed).  Since this call is at the end of the main subroutine we can safely call ApplicationInstance.CompleteRequest()
+        // and avoid unnecessary exceptions.
+        // Sources:
+        // http://stackoverflow.com/questions/14590812/what-is-the-difference-between-use-cases-for-using-response-endfalse-vs-appl
+        // http://weblogs.asp.net/hajan/why-not-to-use-httpresponse-close-and-httpresponse-end
+        // http://stackoverflow.com/questions/1087777/is-response-end-considered-harmful
+        
+        context.ApplicationInstance.CompleteRequest();
     }
 
     public bool IsReusable {


### PR DESCRIPTION
Eliminates the 'System.Threading.ThreadAbortException' that is thrown every time proxy.ashx runs in Visual Studio.