### PR TITLE
POST request in Weblogic throws java.net.ProtocolException

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -269,7 +269,7 @@ java.text.SimpleDateFormat" %>
 
             con.setRequestMethod("POST");
             con.setDoOutput(true);
-
+            con.setRequestProperty("Content-Length", String.valueOf(bytes.length));
 
             OutputStream os = con.getOutputStream();
             os.write(bytes);


### PR DESCRIPTION
In **Weblogic**, a request with **HttpURLConnection** need mandatory the request property "**Content-Length**". Otherwise the following exception is thrown:

A fatal proxy error occurred.
**java.net.ProtocolException**: Exceeding stated content length of 8134
 at weblogic.net.http.ContentLengthOutputStream.write(ContentLengthOutputStream.java:39)
 at weblogic.net.http.ContentLengthOutputStream.write(ContentLengthOutputStream.java:45)
 at jsp_servlet.proxy.doHTTPRequest(__proxy.java:319)
 at jsp_servlet.proxy.forwardToServer(__proxy.java:190)
 at jsp_servlet.proxy._jspService(__proxy.java:1244)
 ....

