### PR TITLE
Fix duplication of headers containing more than one :

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -579,7 +579,7 @@ class Proxy {
         // headers_list() - Returns a list of response headers sent (or ready to send)
         foreach(headers_list() as $key => $value)
         {
-            $pos = strripos($value, ":");
+            $pos = stripos($value, ":");
 
             $header_type = substr($value,0,$pos);
 


### PR DESCRIPTION
The previous behaviour where `$pos` matched on the last occurrence of a colon was breaking for headers like `Expires` that contain colons in the value of the header. As such we were passing a value like "Expires: Tue, 27 Sep 2016 09:" to header_remove(), which resutled in the header not actually being removed.

This caused duplication of headers later when getResponse() added another Expires header.

![headers](https://cloud.githubusercontent.com/assets/5944358/18897705/1d30bd96-855f-11e6-95a3-76a9a1ace994.png)

