### PR TITLE
proxy.php xmlparser constructor

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -2747,7 +2747,7 @@ class XmlParser
 
     public $file;
 
-    function XmlParser($f = "proxy.config")
+    function __construct($f = "proxy.config")
     {
         if(trim($f) != "") { $this->loadFile($f);}
     }


### PR DESCRIPTION
Update XMLParser class to use "__construct" constructor instead of "XMLParser" constructor.  Constructor of same name as class is deprecated in PHP7

