### PR TITLE
Require .net 4.5 in order to support SecurityProtocolType.Tls12

### DIFF
--- a/DotNet/Web.config
+++ b/DotNet/Web.config
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <configuration>
   <system.web>
-    <compilation debug="false" targetFramework="4.0"/>
+    <compilation debug="false" targetFramework="4.5"/>
   </system.web>
   <system.diagnostics>
     <switches>


### PR DESCRIPTION
A solution to #399 

This solution requires .net 4.5

