### PR TITLE
Fix same name constructor error

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -2747,7 +2747,7 @@ class XmlParser
 
     public $file;
 
-    function XmlParser($f = "proxy.config")
+    function __construct($f = "proxy.config")
     {
         if(trim($f) != "") { $this->loadFile($f);}
     }

--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -2848,4 +2848,3 @@ $proxyObject = new Proxy($proxyConfig, $proxyLog);
 
 $proxyObject->getResponse();
 
-?>


### PR DESCRIPTION
The XmlParser class is still using the old php4 method of constructors sharing the same name as the class. Changed construct style to php5^.