### PR TITLE
Java Proxy - Add resets to the response object before reuse.

### DIFF
--- a/Java/proxy.jsp
+++ b/Java/proxy.jsp
@@ -190,7 +190,10 @@ java.text.SimpleDateFormat" %>
             //copy the response content to the response to the client
             InputStream byteStream;
             if (con.getResponseCode() >= 400 && con.getErrorStream() != null){
-                if (ignoreAuthenticationErrors && (con.getResponseCode() == 498 || con.getResponseCode() == 499)) return true;
+                if (ignoreAuthenticationErrors && (con.getResponseCode() == 498 || con.getResponseCode() == 499)){
+                    clientResponse.reset();
+                    return true;
+                }
                 byteStream = con.getErrorStream();
             }else{
                 byteStream = con.getInputStream();
@@ -212,6 +215,7 @@ java.text.SimpleDateFormat" %>
             String strResponse = buffer.toString();
             if (!ignoreAuthenticationErrors && strResponse.contains("error") && (strResponse.contains("\"code\": 498") || strResponse.contains("\"code\": 499")
                     || strResponse.contains("\"code\":498") || strResponse.contains("\"code\":499"))) {
+                clientResponse.reset();
                 return true;
             }
 


### PR DESCRIPTION
While using the java version of the proxy, I noticed that the response body would occasionally be truncated. After some investigation, I realized that this was only happening when the proxy was calling `fetchAndPassBackToClient()` more than once. It appears that the original content length, along with several headers, were being maintained from the original error response, and getting merged with the new, successful response.

To avoid this behavior and start with a fresh response object, I've added resets. More details about what reset does [can be found here](https://docs.oracle.com/javaee/7/api/javax/servlet/ServletResponse.html#reset--).

I've validated this fixes the truncation and extra headers issues.

All testing/dev done on Java 1.7.0_161, with the servlet being hosted by Apache Tomcat/7.0.84