### PR TITLE
Unescape JSON values to avoid malformed URIs

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -886,7 +886,7 @@ public class proxy : IHttpHandler {
                     )
                 );
         }
-        return value;
+        return Regex.Unescape(value);
     }
 
     private int indexOf_HighFlag(string text, string key) {

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -886,7 +886,7 @@ public class proxy : IHttpHandler {
                     )
                 );
         }
-        return Regex.Unescape(value);
+        return value.Replace("\\/", "/");
     }
 
     private int indexOf_HighFlag(string text, string key) {


### PR DESCRIPTION
When used against LocatorHub (our version was 10.2.2), the LocatorHub responses contain escaped forward slashes (`\/`), which in turn causes the requests to end up with the following exception: 

    UriFormatException: Invalid URI: The hostname could not be parsed.

Therefore, we need to unescape the JSON values when they are extracted from the responses to ensure the URIs and tokens are clean.

This effectively addresses #474 