### PR TITLE
Fix php 7 POST request bug

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -1092,7 +1092,7 @@ class Proxy {
         return;
     }
 
-    public function proxyPost($url, $params)
+    public function proxyPost($url = null, $params = null)
     {
         $this->response = null;
 


### PR DESCRIPTION
Update `proxyPost()` constructor properties to accept null values, similar to `proxyGet()`. Closes  #473.