### PR TITLE
bugfix for url query string issue

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -275,6 +275,14 @@ public class proxy : IHttpHandler {
                     tokenParamName = "token";
             }
         }
+		
+		// correct url form & issue, example http://a?b&format=json would forward as
+		// http://b&format=json but should be http://b?format=json
+		// generating an invalid request
+		if (!requestUri.Contains("?") && requestUri.Contains("&"))
+		{
+			requestUri = requestUri.ReplaceFirst("&", "?");
+		}
 
         //forwarding original request
         System.Net.WebResponse serverResponse = null;
@@ -1246,4 +1254,21 @@ public class ServerUrl {
         get { return string.IsNullOrEmpty(rateLimitPeriod)? 60 : int.Parse(rateLimitPeriod); }
         set { rateLimitPeriod = value.ToString(); }
     }
+}
+
+
+/// <summary>
+/// Sauce: https://stackoverflow.com/questions/8809354/replace-first-occurrence-of-pattern-in-a-string?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+/// </summary>
+public static class StringExtensionMethods
+{
+	public static string ReplaceFirst(this string text, string search, string replace)
+	{
+		int pos = text.IndexOf(search);
+		if (pos < 0)
+		{
+			return text;
+		}
+		return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
+	}
 }


### PR DESCRIPTION
This is a resolution to pull request #413 

The basic issue as discussed before, if you have a url http://a?b&f=json it will be translated to a sub-request of http://b&f=json when it should be http://b?f=json

The fix replaces the first occurrence (only) of '&' if a query marker '?' was not found in the sub-request url.