### PR TITLE
Content-Length: 0 Issue

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -368,22 +368,22 @@ public class proxy : IHttpHandler {
     }
 
     private bool writeRequestPostBody(System.Net.HttpWebRequest req, byte[] bytes)
-	{
-		if (bytes != null && bytes.Length > 0)
-		{
-			req.ContentLength = bytes.Length;
-			using (Stream outputStream = req.GetRequestStream())
-			{
-				outputStream.Write(bytes, 0, bytes.Length);
-			}
+    {
+        if (bytes != null && bytes.Length > 0)
+        {
+            req.ContentLength = bytes.Length;
+            using (Stream outputStream = req.GetRequestStream())
+            {
+                outputStream.Write(bytes, 0, bytes.Length);
+            }
 
-			//return true when work was done
-			return true;
-		}
+            //return true when work was done
+            return true;
+        }
 
-		//no work was done
-		return false;
-	}
+        //no work was done
+        return false;
+    }
 
     private System.Net.WebResponse forwardToServer(HttpRequest req, string uri, byte[] postBody, System.Net.NetworkCredential credentials = null)
     {
@@ -392,14 +392,14 @@ public class proxy : IHttpHandler {
         copyRequestHeaders(req, forwardReq);
 		
         if (!writeRequestPostBody(forwardReq, postBody))
-		{
-			// if the content length header was supplied but was not written by the writeRequestPostBody(..) function we write it anyways
-			// to maintain the transparency of the proxy and prevent any response code 411 errors
-			if (!string.IsNullOrEmpty(req.Headers.Get("Content-Length")))
-			{
-				forwardReq.ContentLength = 0;
-			}
-		}
+        {
+            // if the content length header was supplied but was not written by the writeRequestPostBody(..) function we write it anyways
+            // to maintain the transparency of the proxy and prevent any response code 411 errors
+            if (!string.IsNullOrEmpty(req.Headers.Get("Content-Length")))
+            {
+                forwardReq.ContentLength = 0;
+            }
+        }
 		
         return forwardReq.GetResponse();
     }


### PR DESCRIPTION
This is a fix similar to pull request #345.

The issue: If the content length header is sent with an empty post it won't be passed along by the reverse proxy.  This forwards that header if it was orriginally provided to maintain proxy transparency and prevent any response code 411 errors.  A use case of this - if a client is treating a POST as a GET - if the client is a black box (vendor package) you have no control over this.

Public example, if you call direct it works:
curl -X POST -H "Content-Length:0" "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0/query?where=1%3D1&returnGeometry=true&f=pjson"

If you redirect through the proxy it farts with a 411, the header was stripped off:
curl -X POST -H "Content-Length:0" "http://yourhostname/proxy.ashx?https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0/query?where=1%3D1&returnGeometry=true&f=pjson"

For powershell the first example curl is (it puts in the content-length header):
curl -method POST -uri "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0/query?where=1%3D1&returnGeometry=true&f=pjson"

you could argue this is an issue with agol as well