### PR TITLE
It is now possible to proxy a SOAP endpoint

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -622,6 +622,10 @@ public class proxy : IHttpHandler {
                     infoUrl = reqUrl.Substring(0, reqUrl.IndexOf("/sharing/", StringComparison.OrdinalIgnoreCase));
                     infoUrl = infoUrl + "/sharing";
                 }
+                else if (reqUrl.ToLower().Contains("/services/")) {
+                    log(TraceLevel.Info," Adds support for WSDL-based endpoint");
+                    infoUrl = reqUrl.Substring(0, reqUrl.IndexOf("/services/", StringComparison.OrdinalIgnoreCase));
+                }
                 else
                     throw new ApplicationException("Unable to determine the correct URL to request a token to access private resources.");
 


### PR DESCRIPTION
Possible solution to authenticating when using a SOAP endpoint.  Example proxy.config:

```
<?xml version="1.0" encoding="utf-8" ?>
<ProxyConfig>
    <serverUrls>
        <serverUrl url="https://server.com:6443/arcgis" matchAll="true" username="siteadmin" password="********" />
    </serverUrls>
</ProxyConfig>
```

Example usage:

```
https://server.com/proxy/proxy.ashx?https://server.com:6443/arcgis/services/QA/QA/MapServer
```