### PR TITLE
Support for configurable TraceListener

### DIFF
--- a/DotNet/README.md
+++ b/DotNet/README.md
@@ -26,7 +26,7 @@ http://[yourmachine]/DotNet/proxy.ashx?ping
 http://[yourmachine]/DotNet/proxy.ashx?http://services.arcgisonline.com/ArcGIS/rest/services/?f=pjson
 ```
 * Troubleshooting: If you get an error message 404.3, it's possible that ASP.NET have not been set up. On Windows 8, go to "Turn Windows features on or off" -> "Internet Information Services" -> "World Wide Web Services" -> "Application Development Features" -> "ASP.NET 4.5".
-* Edit the proxy.config file in a text editor to set up your [proxy configuration settings](../README.md#proxy-configuration-settings).
+* Edit the proxy.config file in a text editor to set up your [proxy configuration settings](../README.md#proxy-configuration-settings). See below for .NET specific options.
 * Update your application to use the proxy for the specified services. In this JavaScript example requests to route.arcgis.com will utilize the proxy.
 
 ```
@@ -36,6 +36,64 @@ http://[yourmachine]/DotNet/proxy.ashx?http://services.arcgisonline.com/ArcGIS/r
     });
 ```
 * Security tip: By default, the proxy.config allows any referrer. To lock this down, replace the  ```*``` in the ```allowedReferers``` property with your own application URLs.
+
+## .NET Proxy Additional Configuration Settings
+
+The .NET proxy supports specifying an alternative TraceListener implementation for logging. This enables other logging methods such as logging to a database or enterprise logging. You can specify the alternative TraceListener in the proxy config file.
+
+* **logMethod=["class"|"file"|""]** : When set to "class" the log will look at the `logClassTypeName` attribute for the name of a class to use for logging. When set to "file" or if omitted, then the logger will log to a file if such file name is specified with the `logFile` attribute.
+* **logClassTypeName="Fully.Qualified.ClassType.Name"** : Fully qualified name of class to be used as a log. If the class cannot be created, an `InvalidOperationException` will be thrown.
+
+.NET example using a class for logging
+```xml
+
+<ProxyConfig xmlns="proxy.xsd" allowedReferers="*" mustMatch="true"
+  logLevel="Verbose"
+  logMethod="class"
+  logClassTypeName="Company.Product.Web.Infrastructure.ProxyLogTraceListener">
+
+</ProxyConfig>
+```
+
+.NET class utilizing [SimpleInjector](https://simpleinjector.org/index.html) to provide the application logger ([Serilog](https://serilog.net/)).
+```c#
+using Serilog;
+using SimpleInjector.Integration.Web.Mvc;
+using System.Diagnostics;
+using System.Web.Mvc;
+
+namespace Company.Product.Web.Infrastructure
+{
+    /// <summary>
+    /// TraceListener for proxy.ashx. proxy.ashx will create this by name by using Activator.CreateInstance.
+    /// The name of the class is indicated in the proxy.config file.
+    /// </summary>
+    public class ProxyLogTraceListener : TraceListener
+    {
+        public override void Write(string message)
+        {
+            // Get a SimpleInjector lifetime scope. Since Proxy.asax requests are outside the .MVC context a scope
+            // will not be automatically prepared for the request by SimpleInjector. We need to create our own scope
+            // to resolve the log service.
+            SimpleInjector.Container container = ((SimpleInjectorDependencyResolver)DependencyResolver.Current).Container;
+            using (var scope = SimpleInjector.Lifestyles.AsyncScopedLifestyle.BeginScope(container))
+            {
+                ILogger logger = scope.GetInstance<ILogger>();
+                // The TraceListener interface doesn't contain enough information to determine the log level,
+                // So we will settle on using Information.
+                logger.Information(message);
+            }
+        }
+
+        public override void WriteLine(string message)
+        {
+            // Our underlying logger doesn't have any differentiation between write or writeline, so we'll just
+            // pass this along to Write(string)
+            Write(message);
+        }
+    }
+}
+```
 
 ## Folders and Files
 

--- a/DotNet/README.md
+++ b/DotNet/README.md
@@ -1,190 +1,70 @@
-Proxy files for DotNet, Java and PHP
-====================================
+DotNet Proxy File
+=================
 
-These proxy files support:
+A .NET proxy that handles support for
 * Accessing cross domain resources
 * Requests that exceed 2048 characters
 * Accessing resources secured with token based authentication.
-* [OAuth 2.0 app logins](https://developers.arcgis.com/authentication).
+* Accessing resources secured with Microsoft Integrated Windows Authentication (IWA) by using the configured application pool identity for the hosted resource-proxy.
+* [OAuth 2.0 app logins](https://developers.arcgis.com/en/authentication).
 * Enabling logging
 * Both resource and referer based rate limiting
-
-## Alternatives
-There are several good alternative solutions to use instead of your own resource-proxy:
-* [Enable CORS on your server](http://enable-cors.org/server.html) - in order to access cross domain resources.
-* Access secure services [using ArcGIS Online](https://doc.arcgis.com/en/arcgis-online/reference/arcgis-server-services.htm#ESRI_SECTION1_FEB0DF92DA064B6A970DFB59A18AA4C2) to store your username/password credentials. See also the [Working with Proxy Services](https://developers.arcgis.com/authentication/working-with-proxies/) topic.
 
 ## Instructions
 
 * Download and unzip the .zip file or clone the repository. You can download [a released version](https://github.com/Esri/resource-proxy/releases) (recommended) or the [most recent daily build](https://github.com/Esri/resource-proxy/archive/master.zip).
-* Follow the instructions in the readme file in the folder of the proxy you want to install (DotNet, Java, PHP) for installation instructions.
-
-## Folders and Main Files
-
-* [DotNet: .NET version of the proxy](DotNet/README.md)
-    * proxy.ashx
-    * proxy.config
-    * README.md
-* [Java: Java version of the proxy](Java/README.md)
-    * proxy.jsp
-    * WEB-INF/classes/proxy.config
-    * README.md
-* [PHP: PHP version of the proxy](PHP/README.md)
-    * proxy.php
-    * proxy.config
-    * README.md
-
-## Troubleshooting
-
-* Watch the web requests being handled by the proxy to ensure that the proxy and the web resource locations are correct and properly configured in the application. Use something like [Fiddler](http://www.telerik.com/fiddler) or developer tools like [Network panel in Chrome Developer Tools](https://developer.chrome.com/devtools/docs/network#network-panel-overview).
-
-## Product Resources
-
-* [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html)
-
-* [Web AppBuilder for ArcGIS (Developer Edition)](https://developers.arcgis.com/web-appbuilder/guide/use-proxy.htm)
-
-* [Esri Leaflet](https://developers.arcgis.com/authentication/working-with-proxies/#esri-leaflet)
-
-* [Setting up a Proxy blog](http://blogs.esri.com/esri/supportcenter/2015/04/07/setting-up-a-proxy)
-
-## Proxy Configuration Settings
-
-All three proxies respect the XML configuration properties listed below.
-
-* Use the ProxyConfig tag to specify the following proxy level settings.
-    * **mustMatch="true"** : When `true` only the sites listed using serverUrl will be proxied. Set to `false` to proxy any site, which can be useful in testing. However, we recommend setting it to `true` for production sites.
-    * **allowedReferers="http://server.com/app1,http://server.com/app2"** : A comma-separated list of referer URLs. Only requests coming from referers in the list will be proxied. See https://github.com/Esri/resource-proxy/issues/282 for detailed usage.
-    * **logFile="proxylog.txt"** : When a logFile is specified, the proxy will log messages to this file. *N.B.: The folder containing the logFile must be writable by the web server.* If a path is not specified, the .Net proxy uses the folder where the proxy.config file is found. (The Java proxy uses java.util.logging.FileHandler to open the file; the PHP proxy uses fopen to open the file.)
-    * **logLevel="Error"** : An optional flag indicating the level of detail to write to the logFile. Flags for each of the various languages are listed below.
-        *  .Net levels are "Error", "Warning", "Info", and "Verbose" in order from fewest to most messages; the default is "Error".
-        *  Java levels are "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", and "FINEST" in order from fewest to most messages; the default is "SEVERE".
-        *  PHP levels are 0 (writes messages and errors to logs), 1 (shows proxy errors and messages in browser console), 2 (combination of levels 0 and 1), and 3 (no logging); the default is 0.
-new `<serverUrl>` entry for each service that will use the proxy. The proxy.config allows you to use the serverUrl tag to specify one or more ArcGIS Server services that the proxy will forward requests to. The serverUrl tag has the following attributes:
-    * **url**: Location of the ArcGIS Server service (or other URL) to proxy. Specify either the specific URL or the root (in which case you should set matchAll="false").
-    * **matchAll="true"**: When `true` all requests that begin with the specified URL are forwarded. Otherwise, the URL requested must match exactly.
-    * **username**: Username to use when requesting a token - if needed for ArcGIS Server token based authentication.
-    * **password**: Password to use when requesting a token - if needed for ArcGIS Server token based authentication.
-    * **tokenServiceUri**: If username and password are specified, the proxy will use the supplied token service uri to request a token.  If this value is left blank, the proxy will request a token URL from the ArcGIS server.
-    * **useAppPoolIdentity**: When `true`, the IIS application pool identity will be used for authenticating with secured resources. This configuration will supersede the domain, username, and password configurations. The default is `false`. Only applies to DotNet proxy.
-    * **domain**: The Windows domain to use with username/password when using Windows Authentication. Only applies to DotNet proxy.
-    * **clientId**.  Used with clientSecret for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication. **NOTE**: If used to access hosted services, the service(s) must be owned by the user accessing it, (with the exception of credit-based esri services, e.g. routing, geoenrichment, etc.)
-    * **clientSecret**: Used with clientId for OAuth authentication to obtain a token - if needed for OAuth 2.0 authentication.
-    * **oauth2Endpoint**: When using OAuth 2.0 authentication specify the portal specific OAuth 2.0 authentication endpoint. The default value is https://www.arcgis.com/sharing/oauth2/.
-    * **accessToken**: OAuth2 access token to use instead of on-demand access-token generation using clientId & clientSecret. Only applies to DotNet proxy.
-    * **rateLimit**: The maximum number of requests with a particular referer over the specified **rateLimitPeriod**.
-    * **rateLimitPeriod**: The time period (in minutes) within which the specified number of requests (rate_limit) sent with a particular referer will be tracked. The default value is 60 (one hour).
-    * **hostRedirect**: The real URL to use instead of the "alias" one provided in the `url` property and that should be redirected. Example: `<serverUrl url="http://fakedomain" hostRedirect="http://172.16.85.2"/>`.
-
-The .NET version of the proxy supports these additional configuration parameters:
-
-* **logMethod="["class"|"file"|""]"** : When set to `class` the log will look at the `logClassTypeName` attribute for the name of a class to use for logging. When set to `file` or if omitted, then the logger will log to a file if such file name is specified with the `logFile` attribute.
-* **logClassTypeName="Fully.Qualified.ClassType.Name"** : Fully qualified name of class to be used as a log. If the class cannot be created, an `InvalidOperationException` will be thrown.
-
-Note: Refresh the proxy application after updates to the proxy.config have been made.
-
-Example of proxy using application credentials and limiting requests to 10/minute
-```xml
-<serverUrl url="http://route.arcgis.com"
-    clientId="6Xo1d-example-9Kn2"
-    clientSecret="5a5d50-example-c867b6efcf969bdcc6a2"
-    rateLimit="600"
-    rateLimitPeriod="60"
-    matchAll="true">
-</serverUrl>
+* Install the contents of the DotNet folder as a .NET Web Application, specifying a .NET 4.0 application pool or later. For example using the following steps:
+    * Open IIS Manager
+    * If you put the DotNet folder within wwwroot, right-click it and select "Convert to Application".
+    * Make sure the "Application pool" is at least 4.0.
+* Test that the proxy is installed and available:
 ```
-Example of a tag for a resource which does not require authentication
-```xml
-<serverUrl url="http://sampleserver6.arcgisonline.com/arcgis/rest/services"
-    matchAll="true">
-</serverUrl>
+http://[yourmachine]/DotNet/proxy.ashx?ping
 ```
-
-.NET example using a class for logging
-```xml
-
-<ProxyConfig xmlns="proxy.xsd" allowedReferers="*" mustMatch="true"
-  logLevel="Verbose"
-  logMethod="class"
-  logClassTypeName="Company.Product.Web.Infrastructure.ProxyLogTraceListener">
-
-</ProxyConfig>
+* Test that the proxy is able to forward requests directly in the browser using:
 ```
-
-.NET class utilizing [SimpleInjector](https://simpleinjector.org/index.html) to provide the application logger ([Serilog](https://serilog.net/)).
-```c#
-using Serilog;
-using SimpleInjector.Integration.Web.Mvc;
-using System.Diagnostics;
-using System.Web.Mvc;
-
-namespace Company.Product.Web.Infrastructure
-{
-    /// <summary>
-    /// TraceListener for proxy.ashx. proxy.ashx will create this by name by using Activator.CreateInstance.
-    /// The name of the class is indicated in the proxy.config file.
-    /// </summary>
-    public class ProxyLogTraceListener : TraceListener
-    {
-        public override void Write(string message)
-        {
-            // Get a SimpleInjector lifetime scope. Since Proxy.asax requests are outside the .MVC context a scope
-            // will not be automatically prepared for the request by SimpleInjector. We need to create our own scope
-            // to resolve the log service.
-            SimpleInjector.Container container = ((SimpleInjectorDependencyResolver)DependencyResolver.Current).Container;
-            using (var scope = SimpleInjector.Lifestyles.AsyncScopedLifestyle.BeginScope(container))
-            {
-                ILogger logger = scope.GetInstance<ILogger>();
-                // The TraceListener interface doesn't contain enough information to determine the log level,
-                // So we will settle on using Information.
-                logger.Information(message);
-            }
-        }
-
-        public override void WriteLine(string message)
-        {
-            // Our underlying logger doesn't have any differentiation between write or writeline, so we'll just
-            // pass this along to Write(string)
-            Write(message);
-        }
-    }
-}
+http://[yourmachine]/DotNet/proxy.ashx?http://services.arcgisonline.com/ArcGIS/rest/services/?f=pjson
 ```
+* Troubleshooting: If you get an error message 404.3, it's possible that ASP.NET have not been set up. On Windows 8, go to "Turn Windows features on or off" -> "Internet Information Services" -> "World Wide Web Services" -> "Application Development Features" -> "ASP.NET 4.5".
+* Edit the proxy.config file in a text editor to set up your [proxy configuration settings](../README.md#proxy-configuration-settings).
+* Update your application to use the proxy for the specified services. In this JavaScript example requests to route.arcgis.com will utilize the proxy.
+
+```
+    urlUtils.addProxyRule({
+        urlPrefix: "route.arcgis.com",
+        proxyUrl: "http://[yourmachine]/proxy/proxy.ashx"
+    });
+```
+* Security tip: By default, the proxy.config allows any referrer. To lock this down, replace the  ```*``` in the ```allowedReferers``` property with your own application URLs.
+
+## Folders and Files
+
+The proxy consists of the following files:
+* proxy.config: This file contains the [configuration settings for the proxy](../README.md#proxy-configuration-settings). This is where you will define all the resources that will use the proxy. After updating this file you might need to refresh the proxy application using IIS tools in order for the changes to take effect.  **Important note:** In order to keep your credentials safe, ensure that your web server will not display the text inside your proxy.config in the browser (ie: http://[yourmachine]/proxy/proxy.config).
+* proxy.ashx: The actual proxy application. In most cases you will not need to modify this file.
+* proxy.xsd: a schema file for easier editing of proxy.config in Visual Studio.
+* Web.config: An XML file that stores ASP.NET configuration data.
+NOTE: as of v1.1.0, log levels and log file locations are specified in proxy config. By default the proxy will write log messages to a file named auth_proxy.log located in  'C:\Temp\Shared\proxy_logs'. Note that the folder location needs to exist in order for the log file to be successfully created.
 
 ## Requirements
 
-* See the README.md file in the folder of the proxy you want to install for platform specific requirements.
+* ASP.NET 4.0 or greater (4.5 is required on Windows 8/Server 2012, see [this article](http://www.iis.net/learn/get-started/whats-new-in-iis-8/iis-80-using-aspnet-35-and-aspnet-45) for more information)
 
 ## Issues
 
-Found a bug or want to request a new feature? Check out previously logged [Issues](https://github.com/Esri/resource-proxy/issues) and/or our [FAQ](FAQ.md).  If you don't see what you're looking for, feel free to submit a [new issue](https://github.com/Esri/resource-proxy/issues/new).
+Found a bug or want to request a new feature? Let us know by submitting an issue.
 
 ## Contributing
 
-Esri welcomes [contributions](CONTRIBUTING.md) from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
+All contributions are welcome.
 
-## Release steps (for maintainers)
+## Licensing
 
-0. run `npm install gh-release` inside the directory which houses the repository (this only needs to be done once)
-1. bump proxy version numbers and changelog
-2. commit your changes `git commit -m ':package: 1.x.x'`
-3. run `gh-release` at the command line. this will create a tag using the current SHA and use whats in the changelog in the release notes
-
-## License
-
-Copyright 2017 Esri
+Copyright 2014 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
 
-> http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
-
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for specific language governing permissions and limitations under the license.

--- a/DotNet/README.md
+++ b/DotNet/README.md
@@ -41,7 +41,7 @@ http://[yourmachine]/DotNet/proxy.ashx?http://services.arcgisonline.com/ArcGIS/r
 
 The .NET proxy supports specifying an alternative log implementation. This enables other methods of logging such as to a database or another file format.
 
-* **logClass**="Fully.Qualified.Class.Name"** : Optional. If specified, then the proxy will initialize an instance of this class to be used for logging. This option cannot be specified if the `logFile` option is configured. The class must be defined in an assembly that is currently loaded and accessible to the proxy. The class may not be abstract or static, and must have a parameterless constructor. If logClass is not defined then the proxy will default to using the flat log file method.
+* **logClass**="Fully.Qualified.Class.Name" : Optional. If specified, then the proxy will initialize an instance of this class to be used for logging. This option cannot be specified if the `logFile` option is configured. The class must be defined in an assembly that is currently loaded and accessible to the proxy. The class may not be abstract or static, and must have a parameterless constructor.
 * **logClassMethod**="NameOfMethodToCall" : Optional. Default="Log". The proxy will call this method on `logClass` to log. The method must have only one string parameter and may not be generic. Any return value will be ignored.
 
 .NET example using a class for logging

--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -326,7 +326,6 @@ public class proxy : IHttpHandler {
             //first attempt to send the request:
             bool tokenRequired = fetchAndPassBackToClient(serverResponse, response, false);
 
-
             //checking if previously used token has expired and needs to be renewed
             if (tokenRequired) {
                 log(TraceLevel.Info, "Renewing token and trying again.");
@@ -362,7 +361,7 @@ public class proxy : IHttpHandler {
 
     /**
     * Private
-*/
+    */
     private byte[] readRequestPostBody(HttpContext context) {
         if (context.Request.InputStream.Length > 0) {
             byte[] bytes = new byte[context.Request.InputStream.Length];
@@ -991,6 +990,9 @@ class LoggerAdapter
             if (getLogMethod(logger) == null) {
                 throw new InvalidOperationException(string.Format("Class \"{0}\" configured in proxy config for logClass must have a public {1}(string) method.", config.LogClass, _loggerLogMethodName));
             }
+        } else {
+            logger = new NullLogger();
+            _loggerLogMethodName = "Log";
         }
 
         return logger;
@@ -1037,8 +1039,13 @@ class LoggerAdapter
     }
 }
 
-class DefaultLogger
-{
+class NullLogger {
+    public void Log(string message) {
+        // Ignore
+    }
+}
+
+class DefaultLogger {
     private static object _lockobject = new object();
 
     public void Log(string message) {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ There are several good alternative solutions to use instead of your own resource
 
 All three proxies respect the XML configuration properties listed below.
 
-* Use the ProxyConfig tag to specify the following proxy level settings.
+* Use the ProxyConfig tag to specify the following proxy level settings. Look to the README.md under each platform directory for platform-specific log configuration.
     * **mustMatch="true"** : When `true` only the sites listed using serverUrl will be proxied. Set to `false` to proxy any site, which can be useful in testing. However, we recommend setting it to `true` for production sites.
     * **allowedReferers="http://server.com/app1,http://server.com/app2"** : A comma-separated list of referer URLs. Only requests coming from referers in the list will be proxied. See https://github.com/Esri/resource-proxy/issues/282 for detailed usage.
     * **logFile="proxylog.txt"** : When a logFile is specified, the proxy will log messages to this file. *N.B.: The folder containing the logFile must be writable by the web server.* If a path is not specified, the .Net proxy uses the folder where the proxy.config file is found. (The Java proxy uses java.util.logging.FileHandler to open the file; the PHP proxy uses fopen to open the file.)
@@ -60,7 +60,7 @@ All three proxies respect the XML configuration properties listed below.
         *  .Net levels are "Error", "Warning", "Info", and "Verbose" in order from fewest to most messages; the default is "Error".
         *  Java levels are "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", and "FINEST" in order from fewest to most messages; the default is "SEVERE".
         *  PHP levels are 0 (writes messages and errors to logs), 1 (shows proxy errors and messages in browser console), 2 (combination of levels 0 and 1), and 3 (no logging); the default is 0.
-new `<serverUrl>` entry for each service that will use the proxy. The proxy.config allows you to use the serverUrl tag to specify one or more ArcGIS Server services that the proxy will forward requests to. The serverUrl tag has the following attributes:
+* Add a new `<serverUrl>` entry for each service that will use the proxy. The proxy.config allows you to use the serverUrl tag to specify one or more ArcGIS Server services that the proxy will forward requests to. The serverUrl tag has the following attributes:
     * **url**: Location of the ArcGIS Server service (or other URL) to proxy. Specify either the specific URL or the root (in which case you should set matchAll="false").
     * **matchAll="true"**: When `true` all requests that begin with the specified URL are forwarded. Otherwise, the URL requested must match exactly.
     * **username**: Username to use when requesting a token - if needed for ArcGIS Server token based authentication.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,6 @@ new `<serverUrl>` entry for each service that will use the proxy. The proxy.conf
     * **rateLimitPeriod**: The time period (in minutes) within which the specified number of requests (rate_limit) sent with a particular referer will be tracked. The default value is 60 (one hour).
     * **hostRedirect**: The real URL to use instead of the "alias" one provided in the `url` property and that should be redirected. Example: `<serverUrl url="http://fakedomain" hostRedirect="http://172.16.85.2"/>`.
 
-The .NET version of the proxy supports these additional configuration parameters:
-
-* **logMethod="["class"|"file"|""]"** : When set to `class` the log will look at the `logClassTypeName` attribute for the name of a class to use for logging. When set to `file` or if omitted, then the logger will log to a file if such file name is specified with the `logFile` attribute.
-* **logClassTypeName="Fully.Qualified.ClassType.Name"** : Fully qualified name of class to be used as a log. If the class cannot be created, an `InvalidOperationException` will be thrown.
-
 Note: Refresh the proxy application after updates to the proxy.config have been made.
 
 Example of proxy using application credentials and limiting requests to 10/minute
@@ -98,57 +93,6 @@ Example of a tag for a resource which does not require authentication
 <serverUrl url="http://sampleserver6.arcgisonline.com/arcgis/rest/services"
     matchAll="true">
 </serverUrl>
-```
-
-.NET example using a class for logging
-```xml
-
-<ProxyConfig xmlns="proxy.xsd" allowedReferers="*" mustMatch="true"
-  logLevel="Verbose"
-  logMethod="class"
-  logClassTypeName="Company.Product.Web.Infrastructure.ProxyLogTraceListener">
-
-</ProxyConfig>
-```
-
-.NET class utilizing [SimpleInjector](https://simpleinjector.org/index.html) to provide the application logger ([Serilog](https://serilog.net/)).
-```c#
-using Serilog;
-using SimpleInjector.Integration.Web.Mvc;
-using System.Diagnostics;
-using System.Web.Mvc;
-
-namespace Company.Product.Web.Infrastructure
-{
-    /// <summary>
-    /// TraceListener for proxy.ashx. proxy.ashx will create this by name by using Activator.CreateInstance.
-    /// The name of the class is indicated in the proxy.config file.
-    /// </summary>
-    public class ProxyLogTraceListener : TraceListener
-    {
-        public override void Write(string message)
-        {
-            // Get a SimpleInjector lifetime scope. Since Proxy.asax requests are outside the .MVC context a scope
-            // will not be automatically prepared for the request by SimpleInjector. We need to create our own scope
-            // to resolve the log service.
-            SimpleInjector.Container container = ((SimpleInjectorDependencyResolver)DependencyResolver.Current).Container;
-            using (var scope = SimpleInjector.Lifestyles.AsyncScopedLifestyle.BeginScope(container))
-            {
-                ILogger logger = scope.GetInstance<ILogger>();
-                // The TraceListener interface doesn't contain enough information to determine the log level,
-                // So we will settle on using Information.
-                logger.Information(message);
-            }
-        }
-
-        public override void WriteLine(string message)
-        {
-            // Our underlying logger doesn't have any differentiation between write or writeline, so we'll just
-            // pass this along to Write(string)
-            Write(message);
-        }
-    }
-}
 ```
 
 ## Requirements


### PR DESCRIPTION
We have a requirement to log to a SQL server. The pull request adds two new optional configuration options for the ProxyConfig element:

- logMethod : Optional. can specify "class" to indicate a class will be used for logging.
- logClassTypeName : The fully-qualified class name of the TraceListener to use.

I can work on Java and PHP loggers later if this would be required for acceptance into the repo. It is important for our organization to only use the code in this repository in our projects; I am concerned any local changes we make would be clobbered later if we ever pulled changes.
