### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/PHP/proxy.php
+++ b/PHP/proxy.php
@@ -1531,7 +1531,7 @@ class Proxy {
 
     public function endsWith($haystack, $needle) {
         // search forward starting from end minus needle length characters
-        return $needle === "" || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== FALSE);
+        return $needle === "" || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== false);
     }
 
     public function checkAllowedReferer(){


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!