### PR TITLE
Add config option to reject HTML format requests

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -185,8 +185,16 @@ public class proxy : IHttpHandler {
         if (serverUrl.RejectHtmlFormat)
         {
             // f=html OR f param missing (since fallback is normally html when param is missing)
-            Uri reqUri = new Uri(uri);
-            string fParam = HttpUtility.ParseQueryString(reqUri.Query).Get("f");
+            string fParam = null;
+            if (context.Request.HttpMethod == "POST")
+            {
+                fParam = context.Request.Form["f"];
+            }
+            else if (context.Request.HttpMethod == "GET")
+            {
+                Uri reqUri = new Uri(uri);
+                fParam = HttpUtility.ParseQueryString(reqUri.Query).Get("f");
+            }
 
             if (fParam == null || fParam.ToLower() == "html")
             {

--- a/DotNet/proxy.xsd
+++ b/DotNet/proxy.xsd
@@ -21,6 +21,7 @@
                                     <xs:attribute name="rateLimit" type="xs:integer" use="optional" />
                                     <xs:attribute name="rateLimitPeriod" type="xs:integer" use="optional" />
                                     <xs:attribute name="hostRedirect" type="xs:string" use="optional" />
+                                    <xs:attribute name="rejectHtmlFormat" type="xs:boolean" use="optional" />
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ All three proxies respect the XML configuration properties listed below.
     * **rateLimit**: The maximum number of requests with a particular referer over the specified **rateLimitPeriod**.
     * **rateLimitPeriod**: The time period (in minutes) within which the specified number of requests (rate_limit) sent with a particular referer will be tracked. The default value is 60 (one hour).
     * **hostRedirect**: The real URL to use instead of the "alias" one provided in the `url` property and that should be redirected. Example: `<serverUrl url="http://fakedomain" hostRedirect="http://172.16.85.2"/>`.
+    * **rejectHtmlFormat**: When `true`, requests for services in html format are forbidden. This includes requests where the parameter `f` is missing, or if `f=html`. Only applies to DotNet proxy.
 
 Note: Refresh the proxy application after updates to the proxy.config have been made.
 


### PR DESCRIPTION
When HTML format is returned, it contains the username that the
proxy is using. In some situations, this might be considered a
privacy/security issue. This config option enables any html format
request to be rejected without having to disable the entire service
directory.

I've only added the option for DotNet because I don't have a PHP or Java environment to test in.

I know you initially said you would not fix a similar issue (#502) but hopefully now that you understand the scenario a bit more, you will consider it.