### PR TITLE
Prevent .Net server error with unknown referer

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -168,6 +168,7 @@ public class proxy : IHttpHandler {
             {
                 log(TraceLevel.Warning, "Proxy is being used from an unknown referer: " + context.Request.Headers["referer"]);
                 sendErrorResponse(context.Response, "Unsupported referer. ", "403 - Forbidden: Access is denied.", System.Net.HttpStatusCode.Forbidden);
+                return;
             }
 
 


### PR DESCRIPTION
When `allowedReferers` doesn't match a request, the Unsupported referer
error message is displayed. A .Net Server error is also displayed.

![esri-unknown-referer-error](https://user-images.githubusercontent.com/5743159/56247489-28dacc00-6062-11e9-9503-1f470517b618.png)