### PR TITLE
Make Referrer Path case insensitive

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -690,7 +690,7 @@ public class proxy : IHttpHandler {
     private bool pathMatched(String allowedRefererPath, String refererPath)
     {
         //If equal, return true
-        if (refererPath.Equals(allowedRefererPath))
+        if (String.Equals(refererPath, allowedRefererPath, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }


### PR DESCRIPTION
When testing the .NET resource proxy, it was discovered that capital letters in the URL prevented the proxy from recognizing it. This fix makes the URL case insensitive. 